### PR TITLE
stop key search to fix ssh failure

### DIFF
--- a/pyrpl/sshshell.py
+++ b/pyrpl/sshshell.py
@@ -50,7 +50,9 @@ class SshShell(object):
             username=self.user,
             password=self.password,
             port=self.sshport,
-            timeout=timeout)
+            timeout=timeout,
+            look_for_keys=False,
+            allow_agent=False)
         if shell:
             self.channel = self.ssh.invoke_shell()
         self.startscp()


### PR DESCRIPTION
ssh access fails if there are multiple keys in the .ssh host folder.
Failure: Received disconnect from 192.169.0.119 port 22:2: Too many authentication failures

This can be observed on the command line with:
`ssh -v root@rp-xxxxxx`

The fix on the command line is to use:

`ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=password -o PubkeyAuthentication=no root@rp-xxxxxx`

With paramiko module the fix is to add look_for_keys=False and allow_agent=False to the connect