### PR TITLE
enable simple install

### DIFF
--- a/pyrpl/__init__.py
+++ b/pyrpl/__init__.py
@@ -1,5 +1,7 @@
 from ._version import __version_info__, __version__
 
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
 __author__ = "Leonhard Neuhaus <neuhaus@lkb.upmc.fr>"
 __license__ = "MIT License"
 


### PR DESCRIPTION
it is possible to run pyrpl without install.  So if your project python code has "import pyrpl" and your directory structure is:

```
$ ln -s ../pyrpl/pyrpl pyrpl

$ ls -als
project.py
pyrpl -> ../pyrpl/pyrpl
```
then this fix enables you to import the pyrpl code without installing pyrpl.  All you need to do is clone the latest pyrpl repository into the base folder and create the symbolic link from pyrpl/pyrpl to your project folder.

This change works for python2 and python3

Here is a stack exchange discussion of this change
https://stackoverflow.com/questions/52516849/use-init-py-to-modify-sys-path-is-a-good-idea