### PR TITLE
Fixes for async, UI, and typing for latest python and numpy versions

### DIFF
--- a/pyrpl/async_utils.py
+++ b/pyrpl/async_utils.py
@@ -36,10 +36,12 @@ the background loop
 import logging
 from qtpy import QtCore, QtWidgets
 import asyncio
-from asyncio import Future, iscoroutine
-import quamash
+from asyncio import Future, iscoroutine, TimeoutError, get_event_loop, wait_for
 import sys
+import nest_asyncio
+import qasync
 
+nest_asyncio.apply()
 
 logger = logging.getLogger(name=__name__)
 
@@ -47,7 +49,7 @@ logger = logging.getLogger(name=__name__)
 try:
     from IPython import get_ipython
     IPYTHON = get_ipython()
-    IPYTHON.magic("gui qt")
+    IPYTHON.run_line_magic("gui", "qt")
 except BaseException as e:
     logger.debug('Could not enable IPython gui support: %s.' % e)
 
@@ -57,25 +59,48 @@ if APP is None:
     APP = QtWidgets.QApplication(['pyrpl'])
 
 
-LOOP = quamash.QEventLoop() # Since tasks scheduled in this loop seem to
-# fall in the standard QEventLoop, and we never explicitly ask to run this
-# loop, it might seem useless to send all tasks to LOOP, however, a task
-# scheduled in the default loop seem to never get executed with IPython
-# kernel integration.
+LOOP = None  # the main event loop
+INTERACTIVE = True  # True if we are in an interactive IPython session
+
+try:
+    shell = get_ipython().__class__.__name__
+    if shell == 'ZMQInteractiveShell':
+        msg = 'async_utils: Jupyter notebook or qtconsole'
+    elif shell == 'TerminalInteractiveShell':
+        LOOP = qasync.QEventLoop(already_running=False)
+        INTERACTIVE = False
+        msg = 'async_utils: Terminal running IPython'
+    else:
+        LOOP = qasync.QEventLoop(already_running=False)
+        INTERACTIVE = False
+        msg = 'async_utils: # Other type (?)'
+        asyncio.events._set_running_loop(LOOP)
+except NameError:
+    LOOP = qasync.QEventLoop(already_running=False)
+    INTERACTIVE = False
+    msg = 'async_utils: Probably standard Python interpreter'
+    asyncio.events._set_running_loop(LOOP)
+
+logger.debug(msg)
+if INTERACTIVE:
+    nest_asyncio.apply()
 
 async def sleep_async(time_s):
     """
     Replaces asyncio.sleep(time_s) inside coroutines. Deals properly with
     IPython kernel integration.
     """
-    await asyncio.sleep(time_s, loop=LOOP)
+    await asyncio.sleep(time_s)
 
 def ensure_future(coroutine):
     """
     Schedules the task described by the coroutine. Deals properly with
     IPython kernel integration.
     """
-    return asyncio.ensure_future(coroutine, loop=LOOP)
+    if INTERACTIVE:
+        return asyncio.ensure_future(coroutine)
+    else:
+        return asyncio.ensure_future(coroutine, loop=LOOP)
 
 def wait(future, timeout=None):
     """
@@ -89,25 +114,23 @@ def wait(future, timeout=None):
 
     BEWARE: never use wait in a coroutine (use builtin await instead)
     """
-    assert isinstance(future, Future) or iscoroutine(future)
-    new_future = ensure_future(asyncio.wait({future},
-                                            timeout=timeout,
-                                            loop=LOOP))
-    #if sys.version>='3.7': # this way, it was not possible to execute wait
-                            # behind a qt slot !!!
-    #    LOOP.run_until_complete(new_future)
-    #    done, pending = new_future.result()
-    #else:
-    loop = QtCore.QEventLoop()
-    def quit(*args):
-        loop.quit()
-    new_future.add_done_callback(quit)
-    loop.exec_()
-    done, pending = new_future.result()
-    if future in done:
-        return future.result()
+    if INTERACTIVE:
+        new_future = wait_for(future, timeout)
+        loop = get_event_loop()
+        try:
+            return loop.run_until_complete(new_future)
+        except TimeoutError:
+            logger.debug('async_utils wait: Timout exceeded')
     else:
-        raise TimeoutError("Timout exceeded")
+        LOOP.run_until_complete(new_future)
+        done, pending = new_future.result()
+        if future in done:
+            return future.result()
+        else:
+            msg = 'async_utils wait: Timout exceeded'
+            logger.debug(msg)
+            raise TimeoutError("Timout exceeded")
+
 
 def sleep(time_s):
     """
@@ -138,4 +161,4 @@ class Event(asyncio.Event):
     """
 
     def __init__(self):
-        super(Event, self).__init__(loop=LOOP)
+        super(Event, self).__init__()

--- a/pyrpl/attributes.py
+++ b/pyrpl/attributes.py
@@ -787,7 +787,12 @@ class FilterRegister(BaseRegister, FilterProperty):
                 return 32
             else:
                 return int(np.floor(np.log2(float(x))))+1
-        return clog2(125000000.0/float(self._MINBW(obj)))
+        divider = float(self._MINBW(obj))
+        
+        if divider == 0:
+            return clog2(125000000.0/10) # some default value to stop error, see issue #505
+        else:
+            return clog2(125000000.0/divider)
 
     #def _ALPHABITS(self, obj):
     #    return int(np.ceil(np.log2(125000000.0 / self._MINBW(obj))))

--- a/pyrpl/curvedb.py
+++ b/pyrpl/curvedb.py
@@ -59,7 +59,7 @@ except:
             """
             self.logger = logging.getLogger(name=__name__)
             self.params = dict()
-            x, y = np.array([], dtype=np.float), np.array([], dtype=np.float)
+            x, y = np.array([], dtype=np.float64), np.array([], dtype=np.float64)
             self.data = (x, y)
             self.name = name
 
@@ -80,7 +80,7 @@ except:
             kwds will be passed to self.params
             """
             if len(args) == 0:
-                ser = (np.array([], dtype=np.float), np.array([], dtype=np.float))
+                ser = (np.array([], dtype=np.float64), np.array([], dtype=np.float64))
             if len(args) == 1:
                 if isinstance(args[0], pd.Series):
                     x, y = args[0].index.values, args[0].values

--- a/pyrpl/hardware_modules/asg.py
+++ b/pyrpl/hardware_modules/asg.py
@@ -301,7 +301,7 @@ def make_asg(channel=0):
             #    self._reads(self._DATA_OFFSET, self.data_length),
             #             dtype=np.int32)
             x[x >= 2 ** 13] -= 2 ** 14
-            return np.array(x, dtype=np.float) / 2 ** 13
+            return np.array(x, dtype=np.float64) / 2 ** 13
 
         @data.setter
         def data(self, data):

--- a/pyrpl/hardware_modules/iir/iir.py
+++ b/pyrpl/hardware_modules/iir/iir.py
@@ -682,12 +682,12 @@ class IIR(FilterModule):
 
         Returns
         -------
-        tf: np.array(..., dtype=np.complex)
+        tf: np.array(..., dtype=np.complex128)
             The complex open loop transfer function of the module.
         If kind=='all', a list of plotdata tuples is returned that can be
         passed directly to iir.bodeplot().
         """
-        # frequencies = np.array(frequencies, dtype=np.float)
+        # frequencies = np.array(frequencies, dtype=np.float64)
         # take average delay to be half the loops since this is the
         # expectation value for the delay (plus internal propagation delay)
         # module_delay = self._delay + self.loops / 2.0

--- a/pyrpl/hardware_modules/iir/iir_theory.py
+++ b/pyrpl/hardware_modules/iir/iir_theory.py
@@ -90,7 +90,7 @@ def freqs(sys, w):
 
     Returns
     -------
-    np.array(..., dtype=np.complex) with the response
+    np.array(..., dtype=np.complex128) with the response
     """
     z, p, k = sys
     s = np.array(w, dtype=np.complex128) * 1j
@@ -135,7 +135,7 @@ def freqz_(sys, w, dt=8e-9):
 
     Returns
     -------
-    np.array(..., dtype=np.complex) with the response
+    np.array(..., dtype=np.complex128) with the response
     """
     z, p, k = sys
     b, a = sig.zpk2tf(z, p, k)
@@ -877,7 +877,7 @@ class IirFilter(object):
             inputfilter = self.inputfilter
         if frequencies is None:
             frequencies = self.frequencies
-        frequencies = np.asarray(frequencies, dtype=np.complex)
+        frequencies = np.asarray(frequencies, dtype=np.complex128)
         try:
             len(inputfilter)
         except:
@@ -924,7 +924,7 @@ class IirFilter(object):
             frequencies to compute the transfer function for
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         if frequencies is None:
             frequencies = self.frequencies
@@ -948,7 +948,7 @@ class IirFilter(object):
 
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         # this code is more or less a direct copy of get_coeff()
         if frequencies is None:
@@ -985,7 +985,7 @@ class IirFilter(object):
 
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         if frequencies is None:
             frequencies = self.frequencies
@@ -1023,7 +1023,7 @@ class IirFilter(object):
 
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         if frequencies is None:
             frequencies = self.frequencies
@@ -1071,7 +1071,7 @@ class IirFilter(object):
 
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         return self.tf_coefficients(frequencies=frequencies,
                                     coefficients=self.coefficients_rounded,
@@ -1099,7 +1099,7 @@ class IirFilter(object):
 
         Returns
         -------
-        np.array(..., dtype=np.complex)
+        np.array(..., dtype=np.complex128)
         """
         return self.tf_rounded(frequencies=frequencies, delay=True) * \
                self.tf_inputfilter(frequencies=frequencies)

--- a/pyrpl/hardware_modules/iq.py
+++ b/pyrpl/hardware_modules/iq.py
@@ -477,8 +477,8 @@ class Iq(FilterModule):
         self._logger.info("Estimated acquisition time: %.1f s", float(avg + sleeptimes) * points / rbw)
         sys.stdout.flush()  # make sure the time is shown
         # setup averaging
-        self._na_averages = np.int(np.round(125e6 / rbw * avg))
-        self._na_sleepcycles = np.int(np.round(125e6 / rbw * sleeptimes))
+        self._na_averages = np.int64(np.round(125e6 / rbw * avg))
+        self._na_sleepcycles = np.int64(np.round(125e6 / rbw * sleeptimes))
         # compute rescaling factor
         rescale = 2.0 ** (-self._LPFBITS) * 4.0  # 4 is artefact of fpga code
         # obtained by measuring transfer function with bnc cable - could replace the inverse of 4 above
@@ -544,15 +544,15 @@ class Iq(FilterModule):
 
         Returns
         -------
-        tf: np.array(..., dtype=np.complex)
+        tf: np.array(..., dtype=np.complex128)
             The complex open loop transfer function of the module.
         """
         quadrature_delay = 2  # the delay experienced by the signal when it
         # is represented as a quadrature (=lower frequency, less phaseshift)
         # the remaining delay of the module
         module_delay = self._delay - quadrature_delay
-        frequencies = np.array(frequencies, dtype=np.complex)
-        tf = np.array(frequencies * 0, dtype=np.complex) + self.gain
+        frequencies = np.array(frequencies, dtype=np.complex128)
+        tf = np.array(frequencies * 0, dtype=np.complex128) + self.gain
         # bandpass filter
         for f in self.bandwidth:
             if f == 0:

--- a/pyrpl/hardware_modules/pid.py
+++ b/pyrpl/hardware_modules/pid.py
@@ -382,7 +382,7 @@ class Pid(FilterModule):
 
         Returns
         -------
-        tf: np.array(..., dtype=np.complex)
+        tf: np.array(..., dtype=np.complex128)
             The complex open loop transfer function of the module.
         """
         return Pid._transfer_function(frequencies,

--- a/pyrpl/hardware_modules/scope.py
+++ b/pyrpl/hardware_modules/scope.py
@@ -495,7 +495,7 @@ class Scope(HardwareModule, AcquisitionModule):
         return np.array(
             np.roll(self._rawdata_ch1, - (self._write_pointer_trigger +
                                           self._trigger_delay_register + 1)),
-            dtype=np.float) / 2 ** 13
+            dtype=np.float64) / 2 ** 13
 
     @property
     def _data_ch2(self):
@@ -503,21 +503,21 @@ class Scope(HardwareModule, AcquisitionModule):
         return np.array(
             np.roll(self._rawdata_ch2, - (self._write_pointer_trigger +
                                           self._trigger_delay_register + 1)),
-            dtype=np.float) / 2 ** 13
+            dtype=np.float64) / 2 ** 13
 
     @property
     def _data_ch1_current(self):
         """ (unnormalized) data from ch1 while acquisition is still running"""
         return np.array(
             np.roll(self._rawdata_ch1, -(self._write_pointer_current + 1)),
-            dtype=np.float) / 2 ** 13
+            dtype=np.float64) / 2 ** 13
 
     @property
     def _data_ch2_current(self):
         """ (unnormalized) data from ch2 while acquisition is still running"""
         return np.array(
             np.roll(self._rawdata_ch2, -(self._write_pointer_current + 1)),
-            dtype=np.float) / 2 ** 13
+            dtype=np.float64) / 2 ** 13
 
     @property
     def times(self):

--- a/pyrpl/memory.py
+++ b/pyrpl/memory.py
@@ -504,7 +504,7 @@ class MemoryTree(MemoryBranch):
         self._lastsave = time()
         # create a timer to postpone to frequent savings
         self._savetimer = QtCore.QTimer()
-        self._savetimer.setInterval(self._loadsavedeadtime*1000)
+        self._savetimer.setInterval(int(self._loadsavedeadtime*1000))
         self._savetimer.setSingleShot(True)
         self._savetimer.timeout.connect(self._write_to_file)
         self._load()

--- a/pyrpl/software_modules/loop.py
+++ b/pyrpl/software_modules/loop.py
@@ -134,7 +134,7 @@ class PlotWindow(object):
 
     close() closes the plot"""
     def __init__(self, title="plotwindow"):
-        self.win = pg.GraphicsWindow(title=title)
+        self.win = pg.GraphicsLayoutWidget(title=title)
         self.pw = self.win.addPlot()
         self.curves = {}
         self.win.show()

--- a/pyrpl/software_modules/loop.py
+++ b/pyrpl/software_modules/loop.py
@@ -59,7 +59,7 @@ class Loop(Module):
 
     @interval.setter
     def interval(self, val):
-        self.timer.setInterval(val*1000.0)
+        self.timer.setInterval(int(val*1000.0))
 
     def _clear(self):
         self._ended = True

--- a/pyrpl/software_modules/network_analyzer.py
+++ b/pyrpl/software_modules/network_analyzer.py
@@ -240,13 +240,13 @@ class NetworkAnalyzer(AcquisitionModule, SignalModule):
 
         Returns
         -------
-        tf: np.array(..., dtype=np.complex)
+        tf: np.array(..., dtype=np.complex128)
             The complex open loop transfer function of the module.
         """
         module_delay = self._delay
-        frequencies = np.array(np.array(frequencies, dtype=np.float),
-                               dtype=np.complex)
-        tf = np.array(frequencies*0, dtype=np.complex) + 1.0
+        frequencies = np.array(np.array(frequencies, dtype=np.float64),
+                               dtype=np.complex128)
+        tf = np.array(frequencies, dtype=np.complex128) + 1.0
         # input filter modelisation
         f = self.iq.inputfilter  # no for loop here because only one filter
         # stage
@@ -311,10 +311,10 @@ class NetworkAnalyzer(AcquisitionModule, SignalModule):
                 self._current_bandwidth*=2
                 self.iq.bandwidth = [self._current_bandwidth, self._current_bandwidth]
 
-                new_sleep_cycles = np.int(
+                new_sleep_cycles = np.int64(
                     np.round(125e6 / self._current_bandwidth * self.sleeptimes))
                 self.iq._na_sleepcycles = new_sleep_cycles
-                new_na_averages = np.int(np.round(125e6 / self._current_bandwidth *
+                new_na_averages = np.int64(np.round(125e6 / self._current_bandwidth *
                                                        self.average_per_point))
                 self.iq._na_averages = new_na_averages
                 self._cached_na_averages = new_na_averages
@@ -446,10 +446,10 @@ class NetworkAnalyzer(AcquisitionModule, SignalModule):
         self._current_bandwidth = self.iq.bandwidth[0]
 
         # setup averaging
-        self.iq._na_averages = np.int(np.round(125e6 / self._current_bandwidth *
+        self.iq._na_averages = np.int64(np.round(125e6 / self._current_bandwidth *
                                                self.average_per_point))
         self._cached_na_averages = self.iq._na_averages
-        self.iq._na_sleepcycles = np.int(
+        self.iq._na_sleepcycles = np.int64(
             np.round(125e6 / self._current_bandwidth * self.sleeptimes))
         # time_per_point is calculated at setup for speed reasons
         self.time_per_point = self._time_per_point()
@@ -599,7 +599,7 @@ class NetworkAnalyzer(AcquisitionModule, SignalModule):
         self.data_x = self.frequencies if not self.is_zero_span() else \
             np.nan*np.ones(self.points) # Will be filled during acquisition
         self.data_avg = np.zeros(self.points,      # np.empty can create nan
-                                 dtype=np.complex) #and nan*current_avg = nan
+                                 dtype=np.complex128) #and nan*current_avg = nan
                                                    # even if current_avg = 0
 
     @property

--- a/pyrpl/software_modules/spectrum_analyzer.py
+++ b/pyrpl/software_modules/spectrum_analyzer.py
@@ -421,7 +421,7 @@ class SpectrumAnalyzer(AcquisitionModule):
         :return: the product between the complex iq data and the filter_window
         """
         return self._get_iq_data() * np.asarray(self.filter_window(),
-                                            dtype=np.complex)
+                                            dtype=np.complex128)
 
     def useful_index_obsolete(self):
         """

--- a/pyrpl/test/test_hardware_modules/test_pid_na_iq.py
+++ b/pyrpl/test/test_hardware_modules/test_pid_na_iq.py
@@ -46,7 +46,7 @@ class TestPidNaIq(TestPyrpl):
             data = na.single()
             f = na.data_x
             theory = np.array(f * 0 + 1.0,
-                              dtype=np.complex)
+                              dtype=np.complex128)
             # obsolete since na data now comes autocorrected:
             # theory = na.transfer_function(f, extradelay=extradelay)
             relerror = np.abs((data - theory) / theory)
@@ -110,7 +110,7 @@ class TestPidNaIq(TestPyrpl):
             theory = pid.transfer_function(f, extradelay=extradelay)
             relerror = np.abs((data - theory) / theory)
             # get max error for values > -50 dB (otherwise its just NA noise)
-            mask = np.asarray(np.abs(theory) > 3e-3, dtype=np.float)
+            mask = np.asarray(np.abs(theory) > 3e-3, dtype=np.float64)
             maxerror = np.max(relerror*mask)
             if maxerror > error_threshold:
                 print(maxerror)

--- a/pyrpl/widgets/attribute_widgets.py
+++ b/pyrpl/widgets/attribute_widgets.py
@@ -678,7 +678,7 @@ class BoolIgnoreAttributeWidget(BoolAttributeWidget):
             self._gui_to_attribute_mapping.inverse[new_value])
 
 
-class DataWidget(pg.GraphicsWindow):
+class DataWidget(pg.GraphicsLayoutWidget):
     """
     A widget to plot real or complex datasets. To plot data, use the
     function _set_widget_value(new_value, transform_magnitude)
@@ -765,7 +765,7 @@ class PlotAttributeWidget(BaseAttributeWidget):
         Sets the widget (here a QCheckbox)
         :return:
         """
-        self.widget = pg.GraphicsWindow(title="Plot")
+        self.widget = pg.GraphicsLayoutWidget(title="Plot")
         legend = getattr(self.module.__class__, self.attribute_name).legend
         self.pw = self.widget.addPlot(title="%s vs. time (s)"%legend)
         self.plot_start_time = self.time()
@@ -818,7 +818,7 @@ class DataAttributeWidget(PlotAttributeWidget):
     """
 
     def _make_widget(self):
-        self.widget = pg.GraphicsWindow(title="Curve")
+        self.widget = pg.GraphicsLayoutWidget(title="Curve")
         self.plot_item = self.widget.addPlot(title="Curve")
         self.plot_item_phase = self.widget.addPlot(row=1, col=0, title="Phase (deg)")
         self.plot_item_phase.setXLink(self.plot_item)

--- a/pyrpl/widgets/module_widgets/iir_widget.py
+++ b/pyrpl/widgets/module_widgets/iir_widget.py
@@ -11,8 +11,7 @@ from ... import APP
 
 class MyGraphicsLayoutWidget(pg.GraphicsLayoutWidget):
     def __init__(self, title, parent):
-        super(MyGraphicsLayoutWidget, self).__init__(parent, title=title)
-        self.parent = parent
+        super().__init__(parent=parent, title=title)
         self.setToolTip("-----plot legend---------------\n"
                         "yellow: theoretical IIR transfer function\n"
                         "green: data curve\n"
@@ -28,7 +27,7 @@ class MyGraphicsLayoutWidget(pg.GraphicsLayoutWidget):
         #APP.setDoubleClickInterval(300)  # default value (550) is fine
         self.mouse_clicked_timer = QtCore.QTimer()
         self.mouse_clicked_timer.setSingleShot(True)
-        self.mouse_clicked_timer.setInterval(APP.doubleClickInterval())
+        self.mouse_clicked_timer.setInterval(int(APP.doubleClickInterval()))
         self.mouse_clicked_timer.timeout.connect(self.mouse_clicked)
 
     # see https://wiki.python.org/moin/PyQt/Distinguishing%20between%20click%20and%20double%20click

--- a/pyrpl/widgets/module_widgets/iir_widget.py
+++ b/pyrpl/widgets/module_widgets/iir_widget.py
@@ -9,9 +9,9 @@ import numpy as np
 import sys
 from ... import APP
 
-class MyGraphicsWindow(pg.GraphicsWindow):
+class MyGraphicsLayoutWidget(pg.GraphicsLayoutWidget):
     def __init__(self, title, parent):
-        super(MyGraphicsWindow, self).__init__(title)
+        super(MyGraphicsLayoutWidget, self).__init__(parent, title=title)
         self.parent = parent
         self.setToolTip("-----plot legend---------------\n"
                         "yellow: theoretical IIR transfer function\n"
@@ -41,7 +41,7 @@ class MyGraphicsWindow(pg.GraphicsWindow):
             self.parent.module.select_pole_or_zero(self.x)
         if not self.mouse_clicked_timer.isActive():
             self.mouse_clicked_timer.start()
-        return super(MyGraphicsWindow, self).mousePressEvent(event)
+        return super(MyGraphicsLayoutWidget, self).mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
         self.doubleclicked = True
@@ -49,7 +49,7 @@ class MyGraphicsWindow(pg.GraphicsWindow):
         if self.mouse_clicked_timer.isActive():
             self.mouse_clicked_timer.stop()
             self.mouse_clicked()
-        return super(MyGraphicsWindow, self).mouseDoubleClickEvent(event)
+        return super(MyGraphicsLayoutWidget, self).mouseDoubleClickEvent(event)
 
     def storeevent(self, event):
         self.button = event.button()
@@ -89,7 +89,7 @@ class MyGraphicsWindow(pg.GraphicsWindow):
             index = self.parent.module._selected_index
             return self.parent.parent.attribute_widgets[name].widgets[index].keyPressEvent(event)
         except:
-            return super(MyGraphicsWindow, self).keyPressEvent(event)
+            return super(MyGraphicsLayoutWidget, self).keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
         """ not working properly yet"""
@@ -99,7 +99,7 @@ class MyGraphicsWindow(pg.GraphicsWindow):
                 index = self.parent.module._selected_index
                 return self.parent.parent.attribute_widgets[name].widgets[index].keyReleaseEvent(event)
             except:
-                return super(MyGraphicsWindow, self).keyReleaseEvent(event)
+                return super(MyGraphicsLayoutWidget, self).keyReleaseEvent(event)
 
 
 class IirGraphWidget(QtWidgets.QGroupBox):
@@ -113,8 +113,8 @@ class IirGraphWidget(QtWidgets.QGroupBox):
         self.parent = parent
         self.module = self.parent.module
         self.layout = QtWidgets.QVBoxLayout(self)
-        self.win = MyGraphicsWindow(title="Amplitude", parent=self)
-        self.win_phase = MyGraphicsWindow(title="Phase", parent=self)
+        self.win = MyGraphicsLayoutWidget(title="Amplitude", parent=self)
+        self.win_phase = MyGraphicsLayoutWidget(title="Phase", parent=self)
         # self.proxy = pg.SignalProxy(self.win.scene().sigMouseClicked,
         # rateLimit=60, slot=self.mouse_clicked)
         self.mag = self.win.addPlot(title="Magnitude (dB)")
@@ -361,8 +361,8 @@ class IirWidget(ModuleWidget):
                                   list(self._phase(tf)),
                                   brush,
                                   size))]
-            self.graph_widget.plots[end].setPoints(mag)
-            self.graph_widget.plots[end+'_phase'].setPoints(phase)
+            self.graph_widget.plots[end].setData(mag)
+            self.graph_widget.plots[end+'_phase'].setData(phase)
         # plot the measurement data if desired
         if self.module.plot_measurement and hasattr(self.module, '_measurement_data'):
             f, v = self.module._measurement_data
@@ -380,7 +380,7 @@ class IirWidget(ModuleWidget):
             index = self.module._selected_index
             return self.attribute_widgets[name].widgets[index].keyPressEvent(event)
         except:
-            return super(MyGraphicsWindow, self).keyPressEvent(event)
+            return super(MyGraphicsLayoutWidget, self).keyPressEvent(event)
 
     def keyReleaseEvent(self, event):
         """ not working properly yet"""
@@ -390,4 +390,4 @@ class IirWidget(ModuleWidget):
                 index = self.module._selected_index
                 return self.attribute_widgets[name].widgets[index].keyReleaseEvent(event)
             except:
-                return super(MyGraphicsWindow, self).keyReleaseEvent(event)
+                return super(MyGraphicsLayoutWidget, self).keyReleaseEvent(event)

--- a/pyrpl/widgets/module_widgets/lockbox_widget.py
+++ b/pyrpl/widgets/module_widgets/lockbox_widget.py
@@ -435,8 +435,8 @@ class OutputSignalWidget(ModuleWidget):
 
         self.col4.addStretch(5)
 
-        self.win = pg.GraphicsWindow(title="Amplitude")
-        self.win_phase = pg.GraphicsWindow(title="Phase")
+        self.win = pg.GraphicsLayoutWidget(title="Amplitude")
+        self.win_phase = pg.GraphicsLayoutWidget(title="Phase")
         self.plot_item = self.win.addPlot(title="Magnitude (dB)")
         self.plot_item_phase = self.win_phase.addPlot(title="Phase (deg)")
         self.plot_item.showGrid(y=True, x=True, alpha=1.)
@@ -481,7 +481,7 @@ class LockboxInputWidget(ModuleWidget):
         self.init_main_layout(orientation="vertical")
         self.init_attribute_layout()
 
-        self.win = pg.GraphicsWindow(title="Expected signal")
+        self.win = pg.GraphicsLayoutWidget(title="Expected signal")
         self.plot_item = self.win.addPlot(title='Expected ' + self.module.name)
         self.plot_item.showGrid(y=True, x=True, alpha=1.)
         self.curve = self.plot_item.plot(pen='y')

--- a/pyrpl/widgets/module_widgets/module_manager_widget.py
+++ b/pyrpl/widgets/module_widgets/module_manager_widget.py
@@ -131,15 +131,15 @@ class IqManagerWidget(ModuleManagerWidget):
                                       "amplitude", "output_direct"][::2]):
             widget = iq.attribute_widgets[prop]
             self.frames[index].setFixedSize(widget.width() + iq.main_layout.spacing(), self.height())
-            self.frames[index].move(widget.x() + iq.pos().x() - iq.main_layout.spacing() / 2, 0)
+            self.frames[index].move(int(widget.x() + iq.pos().x() - iq.main_layout.spacing() / 2), 0)
 
             self.frames_drawing[index].setFixedSize(widget.width() + iq.main_layout.spacing(), self.height())
-            self.frames_drawing[index].move(widget.x() + iq.pos().x() - self.view.pos().x() - iq.main_layout.spacing() / 2,
+            self.frames_drawing[index].move(int(widget.x() + iq.pos().x() - self.view.pos().x() - iq.main_layout.spacing() / 2),
                                             0)
         self.scene.setSceneRect(QtCore.QRectF(self.view.rect()))
         #x, y = self.view.pos().x(), self.view.pos().y()
         button_width = 150
-        self.button_hide.move(self.width()/2 - button_width/2, self.height() - 17)
+        self.button_hide.move(int(self.width()/2 - button_width/2), int(self.height() - 17))
         self.button_hide.setFixedWidth(button_width)
         self.button_hide.raise_()
 

--- a/pyrpl/widgets/module_widgets/na_widget.py
+++ b/pyrpl/widgets/module_widgets/na_widget.py
@@ -110,7 +110,7 @@ class NaWidget(AcquisitionModuleWidget):
             self.attribute_layout.addWidget(self.groups[label])
             for index, wid in enumerate(wids):
                 self.attribute_layout.removeWidget(aws[wid])
-                self.layout_groups[label].addWidget(aws[wid], index%2 + 1, index/2 + 1)
+                self.layout_groups[label].addWidget(aws[wid], int(index%2 + 1), int(index/2 + 1))
         #########################
 
 

--- a/pyrpl/widgets/module_widgets/na_widget.py
+++ b/pyrpl/widgets/module_widgets/na_widget.py
@@ -65,13 +65,13 @@ class NaWidget(AcquisitionModuleWidget):
         self.button_layout = QtWidgets.QHBoxLayout()
         #self.setLayout(self.main_layout)
         self.setWindowTitle("NA")
-        self.win = pg.GraphicsWindow(title="Magnitude")
+        self.win = pg.GraphicsLayoutWidget(title="Magnitude")
 
         self.label_benchmark = pg.LabelItem(justify='right')
         self.win.addItem(self.label_benchmark, row=1,col=0)
         self._last_benchmark_value = np.nan
 
-        self.win_phase = pg.GraphicsWindow(title="Phase")
+        self.win_phase = pg.GraphicsLayoutWidget(title="Phase")
         self.plot_item = self.win.addPlot(row=1, col=0, title="Magnitude (dB)")
         self.plot_item_phase = self.win_phase.addPlot(row=1, col=0,
                                                       title="Phase (deg)")
@@ -343,9 +343,9 @@ class NaWidget(AcquisitionModuleWidget):
     #    self.module.stop()
 
 
-class MyGraphicsWindow(pg.GraphicsWindow):
+class MyGraphicsLayoutWidget(pg.GraphicsLayoutWidget):
     def __init__(self, title, parent_widget):
-        super(MyGraphicsWindow, self).__init__(title)
+        super(MyGraphicsLayoutWidget, self).__init__(title=title)
         self.parent_widget = parent_widget
         self.setToolTip("IIR transfer function: \n"
                         "----------------------\n"
@@ -375,4 +375,4 @@ class MyGraphicsWindow(pg.GraphicsWindow):
         except BaseException as e:
             self.parent_widget.module._logger.error(e)
         finally:
-            return super(MyGraphicsWindow, self).mousePressEvent(*args, **kwds)
+            return super(MyGraphicsLayoutWidget, self).mousePressEvent(*args, **kwds)

--- a/pyrpl/widgets/module_widgets/schematics.py
+++ b/pyrpl/widgets/module_widgets/schematics.py
@@ -46,7 +46,7 @@ class MyItem(QtWidgets.QWidget):
             self.item.width()/2 + self.item.x()
         y = self.y*self.parent.view.height() - self.item.height()/2 + \
             self.item.y()
-        self.move(x, y)
+        self.move(int(x), int(y))
 
 
 class MyLabel(MyItem):

--- a/pyrpl/widgets/module_widgets/schematics.py
+++ b/pyrpl/widgets/module_widgets/schematics.py
@@ -117,9 +117,9 @@ class Connection(object):
                 x = x2 - self.widget_stop.width() / 2
                 y = y2
                 arrow = QtGui.QPolygonF(
-                    [QtCore.QPoint(x - self.margin, y - self.arrow_height / 2),
-                     QtCore.QPoint(x - self.margin, y + self.arrow_height / 2),
-                     QtCore.QPoint(x - self.margin + self.arrow_width, y)])
+                    [QtCore.QPoint(int(x - self.margin), int(y - self.arrow_height / 2)),
+                     QtCore.QPoint(int(x - self.margin), int(y + self.arrow_height / 2)),
+                     QtCore.QPoint(int(x - self.margin + self.arrow_width), int(y))])
             else:
                 x = x2
                 y = y2 - self.widget_stop.height() / 2
@@ -131,9 +131,9 @@ class Connection(object):
                     margin = self.margin
                     arrow_width = self.arrow_width
                 arrow = QtGui.QPolygonF(
-                    [QtCore.QPoint(x - self.arrow_height / 2, y - margin),
-                     QtCore.QPoint(x + self.arrow_height / 2, y - margin),
-                     QtCore.QPoint(x, y - margin + arrow_width)])
+                    [QtCore.QPoint(int(x - self.arrow_height / 2), int(y - margin)),
+                     QtCore.QPoint(int(x + self.arrow_height / 2), int(y - margin)),
+                     QtCore.QPoint(int(x), int(y - margin + arrow_width))])
 
             if self.show_arrow:
                 self.arrow.setPolygon(arrow)

--- a/pyrpl/widgets/module_widgets/scope_widget.py
+++ b/pyrpl/widgets/module_widgets/scope_widget.py
@@ -121,7 +121,7 @@ class ScopeWidget(AcquisitionModuleWidget):
 
         #self.setLayout(self.main_layout)
         self.setWindowTitle("Scope")
-        self.win = pg.GraphicsWindow(title="Scope")
+        self.win = pg.GraphicsLayoutWidget(title="Scope")
         self.plot_item = self.win.addPlot(title="Scope")
         self.plot_item.showGrid(y=True, alpha=1.)
 

--- a/pyrpl/widgets/module_widgets/spec_an_widget.py
+++ b/pyrpl/widgets/module_widgets/spec_an_widget.py
@@ -153,7 +153,7 @@ class SpecAnWidget(AcquisitionModuleWidget):
         self.button_layout = QtWidgets.QHBoxLayout()
         #self.setLayout(self.main_layout)
         # self.setWindowTitle("Spec. An.")
-        #self.win = pg.GraphicsWindow(title="PSD")
+        #self.win = pg.GraphicsLayoutWidget(title="PSD")
         #self.main_layout.addWidget(self.win)
 
         self.win2 = DataWidget(title='Spectrum')

--- a/pyrpl/widgets/pyrpl_widget.py
+++ b/pyrpl/widgets/pyrpl_widget.py
@@ -117,7 +117,7 @@ class MyDockWidget(QtWidgets.QDockWidget):
                 self.timer = QtCore.QTimer()
                 self.timer.timeout.connect(fn)
                 self.timer.setSingleShot(True)
-                self.timer.setInterval(1.0)
+                self.timer.setInterval(1)
                 self.timer.start()
             event.accept()
             return True
@@ -336,7 +336,7 @@ class PyrplWidget(QtWidgets.QMainWindow):
 
     @window_position.setter
     def window_position(self, coords):
-        self.move(coords[0], coords[1])
+        self.move(int(coords[0]), int(coords[1]))
         self.resize(coords[2], coords[3])
 
     def set_background_color(self, widget):

--- a/setup.py
+++ b/setup.py
@@ -43,18 +43,18 @@ requirements = ['scp',
                 #'ruamel.yaml' # temporarily disabled
                 'pandas',
                 'pyqtgraph',
-                'numpy>=1.9',
+                'numpy>=1.9,<2.0',
                 'paramiko>=2.0',
                 'nose>=1.0',
-                'PyQt5<=5.14',  # cannot be installed with pip
-                'qtpy<=1.9',  # qtpy 1.11 contains breaking API changes related to pyqtSignals
-                'ipykernel>=5,<6',  # otherwise jupyter breaks
+                # 'PyQt5<=5.14',  # Should be installed using conda or system, cannot be installed with pip
+                'qtpy',  
+                'ipykernel',
                 'nbconvert',
-                'jupyter-client']
-if sys.version_info >= (3,4):  # python version dependencies
-    requirements += ['quamash']
-else:  # python 2.7
-    requirements += ['futures', 'mock']  # mock is now a full dependency
+                'jupyter-client',
+                'nest_asyncio',
+                'qasync',
+                ]
+
 if os.environ.get('TRAVIS') == 'true':
     requirements += ['pandoc']
 if os.environ.get('READTHEDOCS') == 'True':
@@ -62,7 +62,7 @@ if os.environ.get('READTHEDOCS') == 'True':
     # remove a few of the mocked modules
     def rtd_included(r):
         for rr in ['numpy', 'scipy', 'pandas', 'scp', 'paramiko', 'nose',
-                   'quamash', 'qtpy', 'asyncio', 'pyqtgraph']:
+                'qtpy', 'asyncio', 'pyqtgraph']:
             if r.startswith(rr):
                 return False
         return True


### PR DESCRIPTION
A collection of changes that removes quamash which doesn't support the latest Python versions, fixes for latest numpy versions which require using float64/complex128/int64 now rather than just float/complex/int. I had a previous pull request but the commits were messy so I squashed them together. Also fixes a divide by zero error on initialisation some people were seeing in issue 505

There are also some helpful changes from peteasa for the async code which got the UI working again.

So far I have only tested this on my Macbook pro with Python 3.12.