### PR TITLE
Update version for python3 support

### DIFF
--- a/pyrpl/_version.py
+++ b/pyrpl/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 9, 6, 0)
+__version_info__ = (1, 0, 0, 0)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
https://github.com/RedPitaya/pyrpl/pull/3 can be safely applied before this pull request.  Other pull requests should wait till after this has been applied.

Suggest that we make main branch python3 only.  This proposed change will mark the start of the python3 development.

There are a number of python3 "enable" pull requests waiting, once merged the python3 tests should mostly run.  Here is the test result for my personal project with these changes already made:

Ran 503 tests in 612.400s
FAILED (failures=2)

To run the tests, apply pull request 3 "enable simple install" and navigate to the folder above the pyrpl library and run
```
python3 -m nose pyrpl
```

nose will search pyrpl/test for all the tests and run each in turn.

The ${HOME}/.noserc configuration file I used was:

```
[nosetests]
verbosity=3
debug-log=nose_debug.log
logging-level=DEBUG
with-coverage=1
cover-html=1
```

Note nose is soon to be depreciated so the test code should be refactored for PyTest